### PR TITLE
Adjust comments in gruntfile to show build steps

### DIFF
--- a/comparison/gruntfile.js
+++ b/comparison/gruntfile.js
@@ -1,13 +1,17 @@
-// Build with Bau at least once before building with other runners to ensure NuGet and xunit.net executables are present
+// Use scriptcs to ensure NuGet and xunit.net executables are present 
+// 1. install scriptcs: http://chocolatey.org/packages/ScriptCs
+// 2. install packages: scriptcs -install
+
+// Next, to build with grunt: 
 // 1. install node:       http://chocolatey.org/packages/nodejs.install
 // 2. install grunt-cli:  npm install -g grunt-cli
 // 3. install modules:    npm install
 // 4. execute gruntfile:  grunt
 
 var nugetCommand = 'packages/NuGet.CommandLine.2.8.1/tools/NuGet.exe';
-var xunitCommand = "packages/xunit.runners.1.9.2/tools/xunit.console.clr4.exe";
+var xunitCommand = 'packages/xunit.runners.1.9.2/tools/xunit.console.clr4.exe';
 var solution = '../src/Bau.sln';
-var test = "../src/test/Bau.Test.Component/bin/Release/Bau.Test.Component.dll";
+var test = '../src/test/Bau.Test.Component/bin/Release/Bau.Test.Component.dll';
 
 path = require('path');
 


### PR DESCRIPTION
The grunt file was pointing at the .sln with the correct relative path. However, it wasn't correctly resolving the packages directory.

The readme at the top of the file didn't specify copying the gruntfile anywhere and so it seemed ok to run it from the comparison directory directly. This works with the change to the packages path.

Also normalized the quotes around strings.
