### PR TITLE
Example with gulpfile

### DIFF
--- a/comparison/gulpfile.js
+++ b/comparison/gulpfile.js
@@ -1,0 +1,49 @@
+// Use scriptcs to ensure NuGet and xunit.net executables are present 
+// 1. install scriptcs: http://chocolatey.org/packages/ScriptCs
+// 2. install packages: scriptcs -install
+
+// Next, to build with gulp: 
+// 1. install node:       http://chocolatey.org/packages/nodejs.install
+// 2. install grunt-cli:  npm install -g gulp
+// 3. install modules:    npm install
+// 4. execute gruntfile:  gulp
+
+// The callbacks are passed in to provide a hint to gulp that these tasks need to run synchronously. I had looked at simply returning the pipe as well
+// so that the tasks would simple chain. However, that didn't work for me.
+
+// I believe this is fairly idiomatic for a gulp impl but I'd prefer someone with more knowledge provide insight.
+
+var nugetCommand = 'packages/NuGet.CommandLine.2.8.1/tools/NuGet.exe';
+var xunitCommand = 'packages/xunit.runners.1.9.2/tools/xunit.console.clr4.exe';
+var solution = '../src/Bau.sln';
+var test = '../src/test/Bau.Test.Component/bin/Release/Bau.Test.Component.dll';
+
+var gulp = require('gulp');
+var msbuild = require('gulp-msbuild');
+var shell = require('gulp-shell')
+
+path = require('path');
+
+gulp.task('clean', function(cb) {
+    gulp.src(solution)
+        .pipe(msbuild({
+            targets: ['Clean'],
+            })
+        );
+	cb();
+});
+
+gulp.task('test', ['build'], shell.task([path.join(__dirname, xunitCommand) + ' ' + test + ' /html ' + test + '.TestResults.html /xml ' + test + '.TestResults.xml']));
+
+gulp.task('restore', shell.task(path.join(__dirname, nugetCommand) + ' restore ' + solution));
+
+gulp.task('build', ['restore'], function(cb) {
+    gulp.src(solution)
+        .pipe(msbuild({
+			configuration: 'Release'
+            })
+        );
+	cb();
+});
+
+gulp.task('default', ['test']);

--- a/comparison/package.json
+++ b/comparison/package.json
@@ -4,6 +4,9 @@
   "devDependencies": {
     "grunt": "^0.4.4",
     "grunt-exec": "^0.4.5",
-    "grunt-msbuild": "^0.1.12"
+    "grunt-msbuild": "^0.1.12",
+    "gulp": "^3.6.2",
+    "gulp-msbuild": "^0.1.5",
+    "gulp-shell": "^0.2.4"
   }
 }


### PR DESCRIPTION
I believe this is an idiomatic example. However, two instances that should
be reviewed:
- shell.task could be replaced with a child_process spawn (removing a dep
  on the shell package)
- We should be able to return the pipe from the clean and build tasks
  rather than forcing the use of a callback to indicate synchronous
  steps. I wasn't able to get that to work though.

closes #82
