### PR TITLE
refactor: remove redundant code

### DIFF
--- a/src/Bau.Test.ruleset
+++ b/src/Bau.Test.ruleset
@@ -1,12 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Bau Test Rules" Description="Bau Test Rules" ToolsVersion="11.0">
+<RuleSet Name="Bau Test Rules" Description="Bau Test Rules" ToolsVersion="12.0">
   <Include Path="allrules.ruleset" Action="Error" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1014" Action="None" />
     <Rule Id="CA1016" Action="None" />
     <Rule Id="CA1017" Action="None" />
+    <Rule Id="CA1020" Action="None" />
+    <Rule Id="CA1026" Action="None" />
     <Rule Id="CA1303" Action="None" />
     <Rule Id="CA1405" Action="None" />
+    <Rule Id="CA1802" Action="None" />
     <Rule Id="CA2210" Action="None" />
   </Rules>
 </RuleSet>

--- a/src/Bau.ruleset
+++ b/src/Bau.ruleset
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Bau Rules" Description="Bau Rules" ToolsVersion="11.0">
+<RuleSet Name="Bau Rules" Description="Bau Rules" ToolsVersion="12.0">
   <Include Path="allrules.ruleset" Action="Error" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1016" Action="None" />
+    <Rule Id="CA1026" Action="None" />
     <Rule Id="CA1303" Action="None" />
     <Rule Id="CA2210" Action="None" />
   </Rules>

--- a/src/Bau/BauScriptPack.cs
+++ b/src/Bau/BauScriptPack.cs
@@ -4,7 +4,6 @@
 
 namespace BauCore
 {
-    using System;
     using ScriptCs.Contracts;
 
     public class BauScriptPack : ScriptPack<Bau>

--- a/src/Bau/Bau{TTask}.cs
+++ b/src/Bau/Bau{TTask}.cs
@@ -41,9 +41,9 @@ namespace BauCore
             this.bau.Execute();
         }
 
-        public IBau Intern<UTask>(string name = Bau.DefaultTask) where UTask : Task, new()
+        public IBau Intern<TNewTask>(string name = Bau.DefaultTask) where TNewTask : Task, new()
         {
-            return this.bau.Intern<UTask>(name);
+            return this.bau.Intern<TNewTask>(name);
         }
 
         IBau IBau.DependsOn(params string[] otherTasks)

--- a/src/Bau/IBau.cs
+++ b/src/Bau/IBau.cs
@@ -16,6 +16,7 @@ namespace BauCore
 
         IBau DependsOn(params string[] otherTasks);
 
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Do", Justification = "By design.")]
         IBau Do(Action action);
 
         void Execute();

--- a/src/Bau/IBau{TTask}.cs
+++ b/src/Bau/IBau{TTask}.cs
@@ -5,11 +5,13 @@
 namespace BauCore
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
 
-    public interface IBau<TTask> : IBau where TTask : Task, new()
+    public interface IBau<out TTask> : IBau where TTask : Task, new()
     {
         new IBau<TTask> DependsOn(params string[] otherTasks);
 
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Do", Justification = "By design.")]
         IBau<TTask> Do(Action<TTask> action);
     }
 }

--- a/src/test/Bau.Test.Acceptance/Plugins/Exec.cs
+++ b/src/test/Bau.Test.Acceptance/Plugins/Exec.cs
@@ -17,7 +17,7 @@ namespace Bau.Test.Acceptance.Plugins
         [Scenario]
         public static void ExecutingACommand(Baufile baufile)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a baufile with an exec task which succeeds"
                 .f(() => baufile = Baufile.Create(scenario, true).WriteLine(
@@ -41,7 +41,7 @@ namespace Bau.Test.Acceptance.Plugins
         [Scenario]
         public static void ExecutingACommandUsingTheExtensionMethod(Baufile baufile)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a baufile with an exec task which uses the Exec extension method"
                 .f(() => baufile = Baufile.Create(scenario, true).WriteLine(
@@ -65,7 +65,7 @@ namespace Bau.Test.Acceptance.Plugins
         [Scenario]
         public static void ExecutingACommandUsingFluentSyntax(Baufile baufile)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a baufile with an exec task which uses the Exec extension method"
                 .f(() => baufile = Baufile.Create(scenario, true).WriteLine(
@@ -84,7 +84,7 @@ namespace Bau.Test.Acceptance.Plugins
         [Scenario]
         public static void ExecutionFails(Baufile baufile, Exception ex)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a baufile with an exec task which fails"
                 .f(() => baufile = Baufile.Create(scenario).WriteLine(

--- a/src/test/Bau.Test.Acceptance/ScriptExecution.cs
+++ b/src/test/Bau.Test.Acceptance/ScriptExecution.cs
@@ -16,7 +16,7 @@ namespace Bau.Test.Acceptance
         [Scenario]
         public static void CompilationFails(Baufile baufile, Exception ex)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a baufile containing an unknown name"
                 .f(() => baufile = Baufile.Create(scenario).WriteLine(@"x"));
@@ -34,7 +34,7 @@ namespace Bau.Test.Acceptance
         [Scenario]
         public static void ExecutionFails(Baufile baufile, Exception ex, string message)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a baufile which throws an exception"
                 .f(() => baufile = Baufile.Create(scenario).WriteLine(

--- a/src/test/Bau.Test.Acceptance/SpecificTasks.cs
+++ b/src/test/Bau.Test.Acceptance/SpecificTasks.cs
@@ -18,7 +18,7 @@ namespace Bau.Test.Acceptance
         [Scenario]
         public static void SingleTask(Baufile baufile, string tempFile, string output)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a baufile with a non-default task"
                 .f(() =>
@@ -42,7 +42,7 @@ namespace Bau.Test.Acceptance
         [Scenario]
         public static void MultipleTasks(Baufile baufile, string tempFile1, string tempFile2, string output)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given bau is required"
                 .f(() => baufile = Baufile.Create(scenario).WriteLine(
@@ -91,9 +91,9 @@ bau.Execute();"));
         [Scenario]
         [Example("NoTask", @"Require<Bau>().Execute();")]
         [Example("SomeOtherTask", @"Require<Bau>().Task(""foo"").Do(() => { }).Execute();")]
-        public static void NonExistentTask(string tag, string code, Baufile baufile, Exception ex)
+        public static void NonexistentTask(string tag, string code, Baufile baufile, Exception ex)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a baufile containing {0}"
                 .f(() => baufile = Baufile.Create(string.Concat(scenario, ".", tag)).WriteLine(code));

--- a/src/test/Bau.Test.Acceptance/Support/BauFile.cs
+++ b/src/test/Bau.Test.Acceptance/Support/BauFile.cs
@@ -7,9 +7,11 @@ namespace Bau.Test.Acceptance.Support
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Linq;
     using System.Text;
+    using LiteGuard;
 
     public class Baufile
     {
@@ -19,6 +21,7 @@ namespace Bau.Test.Acceptance.Support
         private readonly string name;
         private readonly string log;
 
+        [SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline", Justification = "They are initialized inline. The constructor does other things.")]
         static Baufile()
         {
             FileSystem.EnsureDirectoryCreated(directory);
@@ -82,25 +85,25 @@ namespace Bau.Test.Acceptance.Support
 
         public string Execute(params string[] tasks)
         {
-            var info = new ProcessStartInfo();
-            info.FileName = "scriptcs";
+            Guard.AgainstNullArgument("tasks", tasks);
 
-            var args = new List<string>();
-            args.Add(this.name);
-            args.Add("-debug");
-
+            var args = new List<string> { this.name, "-debug" };
             if (tasks.Length > 0)
             {
                 args.Add("--");
                 args.AddRange(tasks);
             }
 
-            info.Arguments = string.Join(" ", args);
-            info.WorkingDirectory = directory;
-            info.UseShellExecute = false;
-            info.CreateNoWindow = true;
-            info.RedirectStandardOutput = true;
-            info.RedirectStandardError = true;
+            var info = new ProcessStartInfo
+            {
+                FileName = "scriptcs",
+                Arguments = string.Join(" ", args),
+                WorkingDirectory = directory,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
 
             var output = new StringBuilder();
             using (var process = new Process())

--- a/src/test/Bau.Test.Acceptance/Support/MethodBaseExtensions.cs
+++ b/src/test/Bau.Test.Acceptance/Support/MethodBaseExtensions.cs
@@ -13,7 +13,9 @@ namespace Bau.Test.Acceptance.Support
         {
             Guard.AgainstNullArgument("method", method);
 
-            return string.Concat(method.DeclaringType.FullName, ".", method.Name);
+            return method.DeclaringType == null
+                ? method.Name
+                : string.Concat(method.DeclaringType.FullName, ".", method.Name);
         }
     }
 }

--- a/src/test/Bau.Test.Acceptance/TaskDependencies.cs
+++ b/src/test/Bau.Test.Acceptance/TaskDependencies.cs
@@ -20,7 +20,7 @@ namespace Bau.Test.Acceptance
         [Scenario]
         public static void SingleDependency(Baufile baufile, string tempFile, string[] executedTasks, string output)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given bau is required"
                 .f(() => baufile = Baufile.Create(scenario).WriteLine(
@@ -84,7 +84,7 @@ bau.Execute();"));
         [Scenario]
         public static void MultipleDependencies(Baufile baufile, string tempFile, string[] executedTasks, string output)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given bau is required"
                 .f(() => baufile = Baufile.Create(scenario).WriteLine(
@@ -160,7 +160,7 @@ bau.Execute();"));
         [Scenario]
         public static void NestedDependencies(Baufile baufile, string tempFile, string[] executedTasks, string output)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given bau is required"
                 .f(() => baufile = Baufile.Create(scenario).WriteLine(
@@ -237,7 +237,7 @@ bau.Execute();"));
         [Scenario]
         public static void RepeatedDependency(Baufile baufile, string tempFile, string[] executedTasks, string output)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given bau is required"
                 .f(() => baufile = Baufile.Create(scenario).WriteLine(
@@ -314,7 +314,7 @@ bau.Execute();"));
         [Scenario]
         public static void CircularDependency(Baufile baufile, string tempFile, string[] executedTasks, string output)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given bau is required"
                 .f(() => baufile = Baufile.Create(scenario).WriteLine(
@@ -380,7 +380,7 @@ bau.Execute();"));
         [Scenario]
         public static void NonexistentDependency(Baufile baufile, string tempFile, Exception ex)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a default task with a non-existent dependency"
                 .f(() => baufile = Baufile.Create(scenario).WriteLine(
@@ -402,7 +402,7 @@ bau.Execute();"));
         [Scenario]
         public static void DependencyFails(Baufile baufile, string tempFile, Exception ex)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given bau is required"
                 .f(() => baufile = Baufile.Create(scenario).WriteLine(

--- a/src/test/Bau.Test.Acceptance/TaskExecution.cs
+++ b/src/test/Bau.Test.Acceptance/TaskExecution.cs
@@ -18,7 +18,7 @@ namespace Bau.Test.Acceptance
         [Scenario]
         public static void DefaultTaskExists(Baufile baufile, string tempFile, string output)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a baufile with a default task"
                 .f(() =>
@@ -47,7 +47,7 @@ namespace Bau.Test.Acceptance
         [Example("SomeOtherTask", @"Require<Bau>().Task(""foo"").Do(() => { }).Execute();")]
         public static void DefaultTaskDoesNotExist(string tag, string code, Baufile baufile, Exception ex)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a baufile containing {0}"
                 .f(() => baufile = Baufile.Create(string.Concat(scenario, ".", tag)).WriteLine(code));
@@ -65,7 +65,7 @@ namespace Bau.Test.Acceptance
         [Scenario]
         public static void ExecutingAnInlineTask(Baufile baufile, string tempFile, string output)
         {
-            var scenario = MethodInfo.GetCurrentMethod().GetFullName();
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a baufile with a default task with an inline task"
                 .f(() =>


### PR DESCRIPTION
rename Intern type parameter on Bau<T>
mark type params covariant
addressed code analysis violations
inlined private method in Bau
renamed TaskInvoker to TaskExecutor
changed static calls on MethodInfo to MethodBase
changed to object initializers where possible
changed MethodBaseExtensions to cope with null DeclaringType
