### PR TITLE
Convert all project reference GUIDs to upper case

### DIFF
--- a/src/Bau.Exec/Bau.Exec.csproj
+++ b/src/Bau.Exec/Bau.Exec.csproj
@@ -61,7 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bau\Bau.csproj">
-      <Project>{3302ec96-f250-49d0-b094-e960355d3799}</Project>
+      <Project>{3302EC96-F250-49D0-B094-E960355D3799}</Project>
       <Name>Bau</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/Bau.Xunit/Bau.Xunit.csproj
+++ b/src/Bau.Xunit/Bau.Xunit.csproj
@@ -61,7 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bau\Bau.csproj">
-      <Project>{3302ec96-f250-49d0-b094-e960355d3799}</Project>
+      <Project>{3302EC96-F250-49D0-B094-E960355D3799}</Project>
       <Name>Bau</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/samples/plugins/Bau.Greeter/Bau.Greeter.csproj
+++ b/src/samples/plugins/Bau.Greeter/Bau.Greeter.csproj
@@ -57,7 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Bau\Bau.csproj">
-      <Project>{3302ec96-f250-49d0-b094-e960355d3799}</Project>
+      <Project>{3302EC96-F250-49D0-B094-E960355D3799}</Project>
       <Name>Bau</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/samples/plugins/Bau.HelloWorld/Bau.HelloWorld.csproj
+++ b/src/samples/plugins/Bau.HelloWorld/Bau.HelloWorld.csproj
@@ -58,7 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Bau\Bau.csproj">
-      <Project>{3302ec96-f250-49d0-b094-e960355d3799}</Project>
+      <Project>{3302EC96-F250-49D0-B094-E960355D3799}</Project>
       <Name>Bau</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/test/Bau.Test.Acceptance/Bau.Test.Acceptance.csproj
+++ b/src/test/Bau.Test.Acceptance/Bau.Test.Acceptance.csproj
@@ -84,7 +84,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bau.Test.Acceptance.CreateFile\Bau.Test.Acceptance.CreateFile.csproj">
-      <Project>{82db9e13-3bcd-408e-b8a0-eb4d92e2ae63}</Project>
+      <Project>{82DB9E13-3BCD-408E-B8A0-EB4D92E2AE63}</Project>
       <Name>Bau.Test.Acceptance.CreateFile</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/test/Bau.Test.Component/Bau.Test.Component.csproj
+++ b/src/test/Bau.Test.Component/Bau.Test.Component.csproj
@@ -88,7 +88,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Bau\Bau.csproj">
-      <Project>{3302ec96-f250-49d0-b094-e960355d3799}</Project>
+      <Project>{3302EC96-F250-49D0-B094-E960355D3799}</Project>
       <Name>Bau</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/test/Bau.Test.Unit/Bau.Test.Unit.csproj
+++ b/src/test/Bau.Test.Unit/Bau.Test.Unit.csproj
@@ -75,7 +75,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Bau\Bau.csproj">
-      <Project>{3302ec96-f250-49d0-b094-e960355d3799}</Project>
+      <Project>{3302EC96-F250-49D0-B094-E960355D3799}</Project>
       <Name>Bau</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/test/Bau.Xunit.Test.Unit/Bau.Xunit.Test.Unit.csproj
+++ b/src/test/Bau.Xunit.Test.Unit/Bau.Xunit.Test.Unit.csproj
@@ -69,11 +69,11 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Bau.Xunit\Bau.Xunit.csproj">
-      <Project>{f930caf5-ea54-4730-8f4c-7d3c8b9f84f0}</Project>
+      <Project>{F930CAF5-EA54-4730-8F4C-7D3C8B9F84F0}</Project>
       <Name>Bau.Xunit</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\Bau\Bau.csproj">
-      <Project>{3302ec96-f250-49d0-b094-e960355d3799}</Project>
+      <Project>{3302EC96-F250-49D0-B094-E960355D3799}</Project>
       <Name>Bau</Name>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
Visual Studio does not care about the case of GUIDs in project references. Xamarin Studio however not only cares, but actively changes the case, causing diffs to appear when the project is opened. This commit changes all of the project reference GUIDs to upper case (which is the standard in the ProjectGuid project property anyway) in order to be compatible with both IDEs.
