### PR TITLE
Initial implementation of inputs/outputs and up-to-date checking

### DIFF
--- a/src/Bau/Bau.cs
+++ b/src/Bau/Bau.cs
@@ -7,6 +7,7 @@ namespace BauCore
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.IO;
     using System.Linq;
     using System.Reflection;
     using ScriptCs.Contracts;
@@ -76,6 +77,20 @@ namespace BauCore
                 this.currentTask.Actions.Add(action);
             }
 
+            return this;
+        }
+
+        public ITaskBuilder InputFile(string inputFileName)
+        {
+            this.EnsureCurrentTask();
+            this.currentTask.InputFile = new FileInfo(inputFileName);
+            return this;
+        }
+
+        public ITaskBuilder OutputFile(string inputFileName)
+        {
+            this.EnsureCurrentTask();
+            this.currentTask.OutputFile = new FileInfo(inputFileName);
             return this;
         }
 
@@ -212,6 +227,12 @@ namespace BauCore
 
         private static void Execute(string task, IBauTask taskRef)
         {
+            if (taskRef.IsUpToDate)
+            {
+                Log.Info(new ColorText("Skipping '", new ColorToken(task, Log.TaskColor), "'"));
+                return;
+            }
+            
             var stopwatch = new Stopwatch();
             stopwatch.Start();
             Log.Info(new ColorText("Starting '", new ColorToken(task, Log.TaskColor), "'..."));

--- a/src/Bau/BauTask.cs
+++ b/src/Bau/BauTask.cs
@@ -6,6 +6,7 @@ namespace BauCore
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using ScriptCs.Contracts;
 
     public class BauTask : ScriptPack<BauTask>, IScriptPackContext, IBauTask
@@ -25,6 +26,26 @@ namespace BauCore
         public IList<Action> Actions
         {
             get { return this.actions; }
+        }
+
+        public FileInfo InputFile
+        {
+            get;
+            set;
+        }
+
+        public FileInfo OutputFile
+        {
+            get;
+            set;
+        }
+
+        public bool IsUpToDate
+        {
+            get
+            {
+                return null != this.InputFile && null != this.OutputFile && (!this.InputFile.Exists || this.InputFile.LastWriteTimeUtc < this.OutputFile.LastWriteTimeUtc);
+            }
         }
 
         public bool Invoked { get; set; }

--- a/src/Bau/IBauTask.cs
+++ b/src/Bau/IBauTask.cs
@@ -6,6 +6,7 @@ namespace BauCore
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
 
     public interface IBauTask
     {
@@ -16,6 +17,23 @@ namespace BauCore
         string Description { get; set; }
 
         IList<Action> Actions { get; }
+
+        FileInfo InputFile
+        {
+            get;
+            set;
+        }
+
+        FileInfo OutputFile
+        {
+            get;
+            set;
+        }
+
+        bool IsUpToDate
+        {
+            get;
+        }
 
         bool Invoked { get; set; }
 

--- a/src/Bau/ITaskBuilder.cs
+++ b/src/Bau/ITaskBuilder.cs
@@ -21,6 +21,10 @@ namespace BauCore
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Do", Justification = "By design.")]
         ITaskBuilder Do(Action action);
 
+        ITaskBuilder InputFile(string inputFileName);
+
+        ITaskBuilder OutputFile(string outputFileName);
+
         void Run();
 
         [Obsolete("Use Run() instead.")]

--- a/src/Bau/ITaskBuilder{TTask}.cs
+++ b/src/Bau/ITaskBuilder{TTask}.cs
@@ -15,5 +15,9 @@ namespace BauCore
 
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Do", Justification = "By design.")]
         ITaskBuilder<TTask> Do(Action<TTask> action);
+
+        new ITaskBuilder<TTask> InputFile(string inputFileName);
+
+        new ITaskBuilder<TTask> OutputFile(string inputFileName);
     }
 }

--- a/src/Bau/TaskBuilder{TTask}.cs
+++ b/src/Bau/TaskBuilder{TTask}.cs
@@ -42,6 +42,18 @@ namespace BauCore
             return this;
         }
 
+        public ITaskBuilder<TTask> InputFile(string inputFileName)
+        {
+            this.builder.InputFile(inputFileName);
+            return this;
+        }
+
+        public ITaskBuilder<TTask> OutputFile(string outputFileName)
+        {
+            this.builder.OutputFile(outputFileName);
+            return this;
+        }
+
         public void Run()
         {
             this.builder.Run();
@@ -71,6 +83,16 @@ namespace BauCore
         public ITaskBuilder Do(Action action)
         {
             return this.builder.Do(action);
+        }
+
+        ITaskBuilder ITaskBuilder.InputFile(string inputFileName)
+        {
+            return this.builder.InputFile(inputFileName);
+        }
+
+        ITaskBuilder ITaskBuilder.OutputFile(string outputFileName)
+        {
+            return this.builder.InputFile(outputFileName);
         }
 
         public void Invoke(string task)

--- a/src/test/Bau.Test.Acceptance/Bau.Test.Acceptance.csproj
+++ b/src/test/Bau.Test.Acceptance/Bau.Test.Acceptance.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Support\Baufile.cs" />
     <Compile Include="Support\MethodBaseExtensions.cs" />
     <Compile Include="DisplayingTasks.cs" />
+    <Compile Include="InputsOutputs.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bau.Test.Acceptance.CreateFile\Bau.Test.Acceptance.CreateFile.csproj">

--- a/src/test/Bau.Test.Acceptance/InputsOutputs.cs
+++ b/src/test/Bau.Test.Acceptance/InputsOutputs.cs
@@ -1,0 +1,265 @@
+﻿// <copyright file="InputsOutputs.cs" company="Bau contributors">
+//  Copyright (c) Bau contributors. (baubuildch@gmail.com)
+// </copyright>
+
+namespace Bau.Test.Acceptance
+{
+    using System;
+    using System.Globalization;
+    using System.IO;
+    using System.Reflection;
+    using Bau.Test.Acceptance.Support;
+    using FluentAssertions;
+    using Xbehave;
+
+    public static class InputsOutputs
+    {
+        [Scenario]
+        public static void InputDoesNotExistNoOutputs(Baufile baufile, string inputFile, string tempFile, string output)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a baufile with a task that declares an input but no output"
+                .f(() =>
+                {
+                    inputFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                    tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                    baufile = Baufile.Create(scenario).WriteLine(
+                        @"Require<Bau>().Task(""default"").InputFile(@""" + inputFile + @""").Do(() => File.Create(@""" + tempFile + @""").Dispose()).Run();");
+                })
+                .Teardown(() => File.Delete(tempFile));
+
+            "When I execute the task"
+                .f(() => output = baufile.Run());
+
+            "Then the task is executed"
+                .f(() => File.Exists(tempFile).Should().BeTrue());
+
+            "And I am informed that the task was started"
+                .f(() => output.Should().ContainEquivalentOf("starting 'default'"));
+        }
+
+        [Scenario]
+        public static void InputExistsNoOutputs(Baufile baufile, string inputFile, string tempFile, string output)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a baufile with a task that declares an input but no output"
+                .f(() =>
+                {
+                    inputFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                    tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                    File.Create(inputFile).Dispose();
+                    baufile = Baufile.Create(scenario).WriteLine(
+                        @"Require<Bau>().Task(""default"").InputFile(@""" + inputFile + @""").Do(() => File.Create(@""" + tempFile + @""").Dispose()).Run();");
+                })
+                .Teardown(() => File.Delete(tempFile))
+                .Teardown(() => File.Delete(inputFile));
+
+            "When I execute the task"
+                .f(() => output = baufile.Run());
+
+            "Then the task is executed"
+                .f(() => File.Exists(tempFile).Should().BeTrue());
+
+            "And I am informed that the task was started"
+                .f(() => output.Should().ContainEquivalentOf("starting 'default'"));
+        }
+
+        [Scenario]
+        public static void NoInputsOutputDoesNotExist(Baufile baufile, string outputFile, string tempFile, string output)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a baufile with a task that declares an input but no output"
+                .f(() =>
+                {
+                    outputFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                    tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                    baufile = Baufile.Create(scenario).WriteLine(
+                        @"Require<Bau>().Task(""default"").OutputFile(@""" + outputFile + @""").Do(() => File.Create(@""" + tempFile + @""").Dispose()).Run();");
+                })
+                .Teardown(() => File.Delete(tempFile));
+
+            "When I execute the task"
+                .f(() => output = baufile.Run());
+
+            "Then the task is executed"
+                .f(() => File.Exists(tempFile).Should().BeTrue());
+
+            "And I am informed that the task was started"
+                .f(() => output.Should().ContainEquivalentOf("starting 'default'"));
+        }
+
+        [Scenario]
+        public static void NoInputsOutputExists(Baufile baufile, string outputFile, string tempFile, string output)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a baufile with a task that declares an input but no output"
+                .f(() =>
+                    {
+                        outputFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        File.Create(outputFile).Dispose();
+                        baufile = Baufile.Create(scenario).WriteLine(
+                            @"Require<Bau>().Task(""default"").OutputFile(@""" + outputFile + @""").Do(() => File.Create(@""" + tempFile + @""").Dispose()).Run();");
+                    })
+                .Teardown(() => File.Delete(tempFile))
+                .Teardown(() => File.Delete(outputFile));
+
+            "When I execute the task"
+                .f(() => output = baufile.Run());
+
+            "Then the task is executed"
+                .f(() => File.Exists(tempFile).Should().BeTrue());
+
+            "And I am informed that the task was started"
+                .f(() => output.Should().ContainEquivalentOf("starting 'default'"));
+        }
+
+        [Scenario]
+        public static void InputDoesNotExistOutputDoesNotExist(Baufile baufile, string inputFile, string outputFile, string tempFile, string output)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a baufile with a task that declares an input but no output"
+                .f(() =>
+                    {
+                        inputFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        outputFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        baufile = Baufile.Create(scenario).WriteLine(
+                            @"Require<Bau>().Task(""default"").InputFile(@""" + inputFile + @""").OutputFile(@""" + outputFile + @""").Do(() => File.Create(@""" + tempFile + @""").Dispose()).Run();");
+                    })
+                .Teardown(() => File.Delete(tempFile));
+
+            "When I execute the task"
+                .f(() => output = baufile.Run());
+
+            "Then the task is NOT executed"
+                .f(() => File.Exists(tempFile).Should().BeFalse());
+
+            "And I am informed that the task was started"
+                .f(() => output.Should().ContainEquivalentOf("skipping 'default'"));
+        }
+
+        [Scenario]
+        public static void InputExistsOutputDoesNotExist(Baufile baufile, string inputFile, string outputFile, string tempFile, string output)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a baufile with a task that declares an input but no output"
+                .f(() =>
+                    {
+                        inputFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        outputFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        File.Create(inputFile).Dispose();
+                        baufile = Baufile.Create(scenario).WriteLine(
+                            @"Require<Bau>().Task(""default"").InputFile(@""" + inputFile + @""").OutputFile(@""" + outputFile + @""").Do(() => File.Create(@""" + tempFile + @""").Dispose()).Run();");
+                    })
+                .Teardown(() => File.Delete(tempFile))
+                .Teardown(() => File.Delete(inputFile));
+
+            "When I execute the task"
+                .f(() => output = baufile.Run());
+
+            "Then the task is executed"
+                .f(() => File.Exists(tempFile).Should().BeTrue());
+
+            "And I am informed that the task was started"
+                .f(() => output.Should().ContainEquivalentOf("starting 'default'"));
+        }
+
+        [Scenario]
+        public static void InputDoesNotExistOutputExists(Baufile baufile, string inputFile, string outputFile, string tempFile, string output)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a baufile with a task that declares an input but no output"
+                .f(() =>
+                    {
+                        inputFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        outputFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        File.Create(outputFile).Dispose();
+                        baufile = Baufile.Create(scenario).WriteLine(
+                            @"Require<Bau>().Task(""default"").InputFile(@""" + inputFile + @""").OutputFile(@""" + outputFile + @""").Do(() => File.Create(@""" + tempFile + @""").Dispose()).Run();");
+                    })
+                .Teardown(() => File.Delete(tempFile))
+                .Teardown(() => File.Delete(outputFile));
+
+            "When I execute the task"
+                .f(() => output = baufile.Run());
+
+            "Then the task is NOT executed"
+                .f(() => File.Exists(tempFile).Should().BeFalse());
+
+            "And I am informed that the task was started"
+                .f(() => output.Should().ContainEquivalentOf("skipping 'default'"));
+        }
+
+        [Scenario]
+        public static void InputIsOlderThanOutput(Baufile baufile, string inputFile, string outputFile, string tempFile, string output)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a baufile with a task that declares an input but no output"
+                .f(() =>
+                    {
+                        inputFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        outputFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        File.Create(inputFile).Dispose();
+                        File.SetLastWriteTimeUtc(inputFile, DateTime.UtcNow.AddDays(-1));
+                        File.Create(outputFile).Dispose();
+                        baufile = Baufile.Create(scenario).WriteLine(
+                            @"Require<Bau>().Task(""default"").InputFile(@""" + inputFile + @""").OutputFile(@""" + outputFile + @""").Do(() => File.Create(@""" + tempFile + @""").Dispose()).Run();");
+                    })
+                .Teardown(() => File.Delete(tempFile))
+                .Teardown(() => File.Delete(inputFile))
+                .Teardown(() => File.Delete(outputFile));
+
+            "When I execute the task"
+                .f(() => output = baufile.Run());
+
+            "Then the task is NOT executed"
+                .f(() => File.Exists(tempFile).Should().BeFalse());
+
+            "And I am informed that the task was started"
+                .f(() => output.Should().ContainEquivalentOf("skipping 'default'"));
+        }
+
+        [Scenario]
+        public static void InputIsNewerThanOutput(Baufile baufile, string inputFile, string outputFile, string tempFile, string output)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a baufile with a task that declares an input but no output"
+                .f(() =>
+                    {
+                        inputFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        outputFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                        File.Create(inputFile).Dispose();
+                        File.Create(outputFile).Dispose();
+                        File.SetLastWriteTimeUtc(outputFile, DateTime.UtcNow.AddDays(-1));
+                        baufile = Baufile.Create(scenario).WriteLine(
+                            @"Require<Bau>().Task(""default"").InputFile(@""" + inputFile + @""").OutputFile(@""" + outputFile + @""").Do(() => File.Create(@""" + tempFile + @""").Dispose()).Run();");
+                    })
+                .Teardown(() => File.Delete(tempFile))
+                .Teardown(() => File.Delete(inputFile))
+                .Teardown(() => File.Delete(outputFile));
+
+            "When I execute the task"
+                .f(() => output = baufile.Run());
+
+            "Then the task is executed"
+                .f(() => File.Exists(tempFile).Should().BeTrue());
+
+            "And I am informed that the task was started"
+                .f(() => output.Should().ContainEquivalentOf("starting 'default'"));
+        }
+    }
+}


### PR DESCRIPTION
This is a first step towards #196. Adds an InputFile and OutputFile method to the DSL, and uses those to skip the task if possible. The intent is to allow multiple input and output files, but even when those have been added, the singular methods will probably be retained for ease of use.

All testing had to be done in Acceptance tests due to the requirement to create real files in the file system for testing. Wondering if it might be worth investing in a file system abstraction library to make it possible to test these kinds of things in the Component tests.

connects to #196
