### PR TITLE
Fix acceptance tests on *nix

### DIFF
--- a/src/test/Bau.Test.Acceptance/Help.cs
+++ b/src/test/Bau.Test.Acceptance/Help.cs
@@ -4,7 +4,9 @@
 
 namespace Bau.Test.Acceptance
 {
+    using System;
     using System.Reflection;
+    using System.Text;
     using Bau.Test.Acceptance.Support;
     using FluentAssertions;
     using Xbehave;
@@ -29,38 +31,38 @@ namespace Bau.Test.Acceptance
             "Then help should be displayed"
                 .f(() =>
                 {
-                    var help =
-@"Copyright (c) Bau contributors (baubuildch@gmail.com)
-
-Usage: scriptcs <filename> -- [tasks|default*] [options]
-
-Options:
-  -T|-tasklist          Display the list of tasks
-                        (d*|descriptive|a|all|p|prerequisites|j|json).
-  -A                    Alias for -tasklist all.
-  -P                    Alias for -tasklist prerequisites.
-  -J                    Alias for -tasklist json.
-  -l|-loglevel <level>  Log at the specified level
-                        (a|all|t|trace|d|debug|i*|info|w|warn|e|error|f|fatal|o|off).
-  -t                    Alias for -loglevel trace.
-  -d                    Alias for -loglevel debug.
-  -q                    Alias for -loglevel warn.
-  -qq                   Alias for -loglevel error.
-  -s                    Alias for -loglevel off.
-  -?|-h|-help           Show help.
-
-  One and two character option aliases are case-sensitive.
-
-Examples:
-  scriptcs baufile.csx                Run the 'default' task.
-  scriptcs baufile.csx -- build test  Run the 'build' and 'test' tasks.
-  scriptcs baufile.csx -- -l d        Run the 'default' task and log at debug level.
-  scriptcs baufile.csx -- -T          Display the list of tasks with descriptions.
-  scriptcs baufile.csx -- -T p        Display the list of tasks and prerequisites.
-
-* Default value.
-
-";
+                    var help = new StringBuilder()
+                        .AppendLine(@"Copyright (c) Bau contributors (baubuildch@gmail.com)")
+                        .AppendLine()
+                        .AppendLine("Usage: scriptcs <filename> -- [tasks|default*] [options]")
+                        .AppendLine()
+                        .AppendLine("Options:")
+                        .AppendLine("  -T|-tasklist          Display the list of tasks")
+                        .AppendLine("                        (d*|descriptive|a|all|p|prerequisites|j|json).")
+                        .AppendLine("  -A                    Alias for -tasklist all.")
+                        .AppendLine("  -P                    Alias for -tasklist prerequisites.")
+                        .AppendLine("  -J                    Alias for -tasklist json.")
+                        .AppendLine("  -l|-loglevel <level>  Log at the specified level")
+                        .AppendLine("                        (a|all|t|trace|d|debug|i*|info|w|warn|e|error|f|fatal|o|off).")
+                        .AppendLine("  -t                    Alias for -loglevel trace.")
+                        .AppendLine("  -d                    Alias for -loglevel debug.")
+                        .AppendLine("  -q                    Alias for -loglevel warn.")
+                        .AppendLine("  -qq                   Alias for -loglevel error.")
+                        .AppendLine("  -s                    Alias for -loglevel off.")
+                        .AppendLine("  -?|-h|-help           Show help.")
+                        .AppendLine()
+                        .AppendLine("  One and two character option aliases are case-sensitive.")
+                        .AppendLine()
+                        .AppendLine("Examples:")
+                        .AppendLine("  scriptcs baufile.csx                Run the 'default' task.")
+                        .AppendLine("  scriptcs baufile.csx -- build test  Run the 'build' and 'test' tasks.")
+                        .AppendLine("  scriptcs baufile.csx -- -l d        Run the 'default' task and log at debug level.")
+                        .AppendLine("  scriptcs baufile.csx -- -T          Display the list of tasks with descriptions.")
+                        .AppendLine("  scriptcs baufile.csx -- -T p        Display the list of tasks and prerequisites.")
+                        .AppendLine()
+                        .AppendLine("* Default value.")
+                        .AppendLine()
+                        .ToString();
 
                     output.Should().Contain(help);
                 });

--- a/src/test/Bau.Test.Acceptance/Support/Baufile.cs
+++ b/src/test/Bau.Test.Acceptance/Support/Baufile.cs
@@ -31,11 +31,11 @@ namespace Bau.Test.Acceptance.Support
             var assemblyDirectories = new[]
             {
 #if DEBUG
-                @"..\..\..\..\Bau\bin\Debug",
-                @"..\..\..\..\Bau.Exec\bin\Debug",
+                @"../../../../Bau/bin/Debug",
+                @"../../../../Bau.Exec/bin/Debug",
 #else
-                @"..\..\..\..\Bau\bin\Release",
-                @"..\..\..\..\Bau.Exec\bin\Release",
+                @"../../../../Bau/bin/Release",
+                @"../../../../Bau.Exec/bin/Release",
 #endif
             };
 


### PR DESCRIPTION
Progress toward #151. Tested on OS X.

There are two tests still failing, both because ScriptCS is not reporting a failure exit code when compilation fails. I have reported that at scriptcs/scriptcs#1054.

I am including a change to the Travis CI config that will run the acceptance tests so I can verify that only the tests that are expected to fail will fail on CI. Then I will revert that change.

connects to #151
