### PR TITLE
Specify version in pack command to eliminate need for nuspec rewrite

### DIFF
--- a/baufile.csx
+++ b/baufile.csx
@@ -138,36 +138,19 @@ bau.Task("build").DependsOn("clean", "restore", "logs")
     {
         foreach (var pack in packs)
         {
-            File.Copy(pack + ".nuspec", pack + ".nuspec.original", true);
-        }
+            var project = pack + ".csproj";
+            bau.CurrentTask.LogInfo("Packing '" + project + "'...");
 
-        try
-        {
-            foreach (var pack in packs)
-            {
-                File.WriteAllText(pack + ".nuspec", File.ReadAllText(pack + ".nuspec").Replace("0.0.0", version + versionSuffix));
-
-                var project = pack + ".csproj";
-                bau.CurrentTask.LogInfo("Packing '" + project + "'...");
-                
-                new Exec { Name = "pack " + project }
-                    .Run(nugetCommand)
-                    .With(
-                        "pack", project,
-                        "-OutputDirectory", output,
-                        "-Properties", "Configuration=Release",
-                        "-IncludeReferencedProjects",
-                        "-Verbosity " + nugetVerbosity)
-                    .Execute();
-            }
-        }
-        finally
-        {
-            foreach (var pack in packs)
-            {
-                File.Copy(pack + ".nuspec.original", pack + ".nuspec", true);
-                File.Delete(pack + ".nuspec.original");
-            }
+            new Exec { Name = "pack " + project }
+                .Run(nugetCommand)
+                .With(
+                    "pack", project,
+                    "-Version", version + versionSuffix,
+                    "-OutputDirectory", output,
+                    "-Properties", "Configuration=Release",
+                    "-IncludeReferencedProjects",
+                    "-Verbosity " + nugetVerbosity)
+                .Execute();
         }
     })
 


### PR DESCRIPTION
The "pack" task of the build currently rewrites all of the nuspecs in order to include the generated version number. We can avoid the need to rewrite the nuspecs by specifying the version as an argument to the NuGet pack command instead.
