### PR TITLE
Correctly forward arguments for Unix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@ set -e
 set -o pipefail
 set -x
 
-scriptcs ./baufile.csx -- "$@"
+exec scriptcs ./baufile.csx -- "$@"

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@ set -e
 set -o pipefail
 set -x
 
-scriptcs ./baufile.csx -- $@
+scriptcs ./baufile.csx -- "$@"


### PR DESCRIPTION
Using `$@` to forward arguments will break for arguments with whitespace. Using `"$@"` preserves this, e.g. `./build.sh 'foo bar' baz` will call `scriptcs ./baufile.csx 'foo bar' baz` and not `scriptcs ./baufile.csx foo bar baz`.
