### PR TITLE
Support for aliases

### DIFF
--- a/src/Bau/Bau.cs
+++ b/src/Bau/Bau.cs
@@ -69,7 +69,7 @@ namespace BauCore
                 if (string.IsNullOrWhiteSpace(alias))
                 {
                     var message = new ColorText(
-                        "Invalid aliase name '", new ColorToken(alias, Log.TaskColor), "'.");
+                        "Invalid alias name '", new ColorToken(alias, Log.TaskColor), "'.");
 
                     Log.Error(message);
                     throw new ArgumentException(message.ToString(), "aliases");

--- a/src/Bau/Bau.cs
+++ b/src/Bau/Bau.cs
@@ -61,6 +61,26 @@ namespace BauCore
             return this;
         }
 
+        public ITaskBuilder WithAliases(params string[] aliases)
+        {
+            this.EnsureCurrentTask();
+            foreach (var alias in aliases.Where(a => !this.currentTask.Aliases.Contains(a)))
+            {
+                if (string.IsNullOrWhiteSpace(alias))
+                {
+                    var message = new ColorText(
+                        "Invalid aliase name '", new ColorToken(alias, Log.TaskColor), "'.");
+
+                    Log.Error(message);
+                    throw new ArgumentException(message.ToString(), "aliases");
+                }
+
+                this.currentTask.Aliases.Add(alias);
+            }
+
+            return this;
+        }
+
         public ITaskBuilder Desc(string description)
         {
             this.EnsureCurrentTask();
@@ -252,6 +272,11 @@ namespace BauCore
         {
             try
             {
+                var taskWithAlias = this.tasks.Values.SingleOrDefault(v => v.Aliases.Contains(task));
+                if (taskWithAlias != null)
+                {
+                    task = taskWithAlias.Name;
+                }
                 return this.tasks[task];
             }
             catch (KeyNotFoundException ex)

--- a/src/Bau/Bau.cs
+++ b/src/Bau/Bau.cs
@@ -276,6 +276,11 @@ namespace BauCore
                 if (taskWithAlias != null)
                 {
                     task = taskWithAlias.Name;
+                    
+                    Log.Info(new ColorText(
+                            "Actual task name '",
+                            new ColorToken(task, Log.TaskColor),
+                            "'"));
                 }
                 return this.tasks[task];
             }

--- a/src/Bau/Bau.cs
+++ b/src/Bau/Bau.cs
@@ -276,11 +276,11 @@ namespace BauCore
                 if (taskWithAlias != null)
                 {
                     task = taskWithAlias.Name;
-                    
+
                     Log.Info(new ColorText(
-                            "Actual task name '",
-                            new ColorToken(task, Log.TaskColor),
-                            "'"));
+                                 "Actual task name '",
+                                 new ColorToken(task, Log.TaskColor),
+                                 "'"));
                 }
                 return this.tasks[task];
             }
@@ -290,6 +290,16 @@ namespace BauCore
                     "'",
                     new ColorToken(task, Log.TaskColor),
                     "' task not found.");
+
+                Log.Error(message);
+                throw new InvalidOperationException(message.ToString(), ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                var message = new ColorText(
+                    "'",
+                    new ColorToken(task, Log.TaskColor),
+                    "' alias was assigned for multiple tasks.");
 
                 Log.Error(message);
                 throw new InvalidOperationException(message.ToString(), ex);

--- a/src/Bau/BauTask.cs
+++ b/src/Bau/BauTask.cs
@@ -12,6 +12,7 @@ namespace BauCore
     {
         private readonly List<string> dependencies = new List<string>();
         private readonly List<Action> actions = new List<Action>();
+        private readonly List<string> aliases = new List<string>(); 
 
         public string Name { get; set; }
 
@@ -25,6 +26,11 @@ namespace BauCore
         public IList<Action> Actions
         {
             get { return this.actions; }
+        }
+
+        public IList<string> Aliases
+        {
+            get { return this.aliases; }
         }
 
         public bool Invoked { get; set; }

--- a/src/Bau/IBauTask.cs
+++ b/src/Bau/IBauTask.cs
@@ -17,6 +17,8 @@ namespace BauCore
 
         IList<Action> Actions { get; }
 
+        IList<string> Aliases { get; } 
+
         bool Invoked { get; set; }
 
         void Execute();

--- a/src/Bau/ITaskBuilder.cs
+++ b/src/Bau/ITaskBuilder.cs
@@ -16,6 +16,8 @@ namespace BauCore
 
         ITaskBuilder DependsOn(params string[] otherTasks);
 
+        ITaskBuilder WithAliases(params string[] aliases);
+
         ITaskBuilder Desc(string description);
 
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Do", Justification = "By design.")]

--- a/src/Bau/TaskBuilder{TTask}.cs
+++ b/src/Bau/TaskBuilder{TTask}.cs
@@ -29,6 +29,12 @@ namespace BauCore
             return this;
         }
 
+        public ITaskBuilder WithAliases(params string[] aliases)
+        {
+            this.builder.WithAliases(aliases);
+            return this;
+        }
+
         public ITaskBuilder<TTask> Desc(string description)
         {
             this.builder.Desc(description);

--- a/src/test/Bau.Test.Acceptance/SpecificTasks.cs
+++ b/src/test/Bau.Test.Acceptance/SpecificTasks.cs
@@ -164,5 +164,28 @@ bau.Run();"));
             "And I am informed that the task and dependencies were completed after a period of time"
                 .f(() => output.Should().ContainEquivalentOf("Completed 'nd' and dependencies in "));
         }
+
+        [Scenario]
+        [Example("MultipleTasksWithSameAlias", @"Require<Bau>().Task(""foo"")
+                                                  .WithAliases(""nd"").Do(() => { })
+                                                  .Task(""bar"")
+                                                  .WithAliases(""nd"").Do(() => { })
+                                                  .Run();")]
+        public static void MultipleMatchingTasksWithanAlias(string tag, string code, Baufile baufile, Exception ex)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a baufile containing {0}"
+                .f(() => baufile = Baufile.Create(string.Concat(scenario, ".", tag)).WriteLine(code));
+
+            "When I execute a task with an alias and is duplicated"
+                .f(() => ex = Record.Exception(() => baufile.Run("nd")));
+
+            "Then execution should fail"
+                .f(() => ex.Should().NotBeNull());
+
+            "And I am informed that the non-existent task was not found"
+                .f(() => ex.Message.Should().ContainEquivalentOf("'nd' alias was assigned for multiple tasks"));
+        }
     }
 }

--- a/src/test/Bau.Test.Acceptance/SpecificTasks.cs
+++ b/src/test/Bau.Test.Acceptance/SpecificTasks.cs
@@ -178,7 +178,7 @@ bau.Run();"));
             "Given a baufile containing {0}"
                 .f(() => baufile = Baufile.Create(string.Concat(scenario, ".", tag)).WriteLine(code));
 
-            "When I execute a task with an alias and is duplicated"
+            "When I execute a task with an alias which is also used for another task"
                 .f(() => ex = Record.Exception(() => baufile.Run("nd")));
 
             "Then execution should fail"

--- a/src/test/Bau.Test.Acceptance/SpecificTasks.cs
+++ b/src/test/Bau.Test.Acceptance/SpecificTasks.cs
@@ -152,6 +152,9 @@ bau.Run();"));
             "And I am informed that the task and dependencies are being run"
                 .f(() => output.Should().ContainEquivalentOf("Running 'nd' and dependencies"));
 
+            "And I am informed that I ran the task using an alias"
+                .f(() => output.Should().ContainEquivalentOf("Actual task name 'non-default'"));
+
             "And I am informed that the task was started"
                 .f(() => output.Should().ContainEquivalentOf("starting 'nd'"));
 

--- a/src/test/Bau.Test.Acceptance/SpecificTasks.cs
+++ b/src/test/Bau.Test.Acceptance/SpecificTasks.cs
@@ -128,5 +128,38 @@ bau.Run();"));
             "And I am informed that the non-existent task was not found"
                 .f(() => ex.Message.Should().ContainEquivalentOf("'non-existent' task not found"));
         }
+
+        [Scenario]
+        public static void AliasedTask(Baufile baufile, string tempFile, string output)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a baufile with a non-default task with an alias set as nd"
+                .f(() =>
+                {
+                    tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+                    baufile = Baufile.Create(scenario).WriteLine(
+                    @"Require<Bau>().Task(""non-default"").WithAliases(""nd"").Do(() => File.Create(@""" + tempFile + @""").Dispose()).Run();");
+                })
+                .Teardown(() => File.Delete(tempFile));
+
+            "When I execute the non-default task using an alias"
+                .f(() => output = baufile.Run("nd"));
+
+            "Then the task is executed"
+                .f(() => File.Exists(tempFile).Should().BeTrue());
+
+            "And I am informed that the task and dependencies are being run"
+                .f(() => output.Should().ContainEquivalentOf("Running 'nd' and dependencies"));
+
+            "And I am informed that the task was started"
+                .f(() => output.Should().ContainEquivalentOf("starting 'nd'"));
+
+            "And I am informed that the task was finished after a period of time"
+                .f(() => output.Should().ContainEquivalentOf("finished 'nd' after "));
+
+            "And I am informed that the task and dependencies were completed after a period of time"
+                .f(() => output.Should().ContainEquivalentOf("Completed 'nd' and dependencies in "));
+        }
     }
 }

--- a/src/test/Bau.Test.Acceptance/SpecificTasks.cs
+++ b/src/test/Bau.Test.Acceptance/SpecificTasks.cs
@@ -184,7 +184,7 @@ bau.Run();"));
             "Then execution should fail"
                 .f(() => ex.Should().NotBeNull());
 
-            "And I am informed that the non-existent task was not found"
+            "And I am informed that the alias was used for multiple tasks"
                 .f(() => ex.Message.Should().ContainEquivalentOf("'nd' alias was assigned for multiple tasks"));
         }
     }


### PR DESCRIPTION
This is a change to the core, but hope its accepted! I just added some support for aliases w/ tests, since I noticed I ran specific tasks all the time & was getting lazy with typing full task names!! By the way, bau is so helpful, thanks!!

Some details - with these commits, we can assign aliases for tasks, like,

```
Require<Bau>()
        .Task("long-task-name")
        .WithAliases("ltn")
        .Do(() => { })
        .Run();
```

And call them with the defined alias!

```
scriptcs .\baufile.csx -- ltn
```

connects to #229
