### PR TITLE
Ability to pass parameters to the script being executed

### DIFF
--- a/src/Bau/Arguments.cs
+++ b/src/Bau/Arguments.cs
@@ -281,7 +281,7 @@ namespace BauCore
 
                         break;
                     case "CONFIG":
-                        namedParameters = option.Value?? new List<string>();
+                        namedParameters = option.Value ?? new List<string>();
                         break;
                     case "TASKLIST":
                         var taskListTypes = option.Value;

--- a/src/Bau/Arguments.cs
+++ b/src/Bau/Arguments.cs
@@ -16,12 +16,14 @@ namespace BauCore
         private readonly LogLevel logLevel;
         private readonly TaskListType? taskListType;
         private readonly bool help;
+        private readonly List<string> namedParameters; 
 
         public Arguments(
             IEnumerable<string> tasks,
             LogLevel logLevel,
             TaskListType? taskListType,
-            bool help)
+            bool help,
+            List<string> namedParameters)
         {
             Guard.AgainstNullArgument("tasks", tasks);
 
@@ -29,6 +31,7 @@ namespace BauCore
             this.logLevel = logLevel;
             this.taskListType = taskListType;
             this.help = help;
+            this.namedParameters = namedParameters;
         }
 
         public IEnumerable<string> Tasks
@@ -48,7 +51,7 @@ namespace BauCore
         
         public List<string> NamedParameters
         {
-            get { throw new NotImplementedException(); }
+            get { return namedParameters; }
         }
 
         public bool Help
@@ -264,6 +267,7 @@ namespace BauCore
             var logLevel = LogLevel.Info;
             var help = false;
             var taskListType = default(TaskListType?);
+            var namedParameters = new List<string>();
             foreach (var option in Parse(args, tasks))
             {
                 switch (option.Key.ToUpperInvariant())
@@ -276,7 +280,9 @@ namespace BauCore
                         }
 
                         break;
-
+                    case "CONFIG":
+                        namedParameters = option.Value?? new List<string>();
+                        break;
                     case "TASKLIST":
                         var taskListTypes = option.Value;
                         taskListType = taskListTypes.Any()
@@ -297,7 +303,7 @@ namespace BauCore
                 }
             }
 
-            return new Arguments(tasks, logLevel, taskListType, help);
+            return new Arguments(tasks, logLevel, taskListType, help, namedParameters);
         }
 
         private static Dictionary<string, List<string>> Parse(IEnumerable<string> args, ICollection<string> tasks)
@@ -376,6 +382,9 @@ namespace BauCore
                 case "s":
                     impliedValue = "OFF";
                     return "LOGLEVEL";
+                case "p":
+                    impliedValue = "";
+                    return "CONFIG";
                 case "h":
                 case "?":
                     return "HELP";

--- a/src/Bau/Arguments.cs
+++ b/src/Bau/Arguments.cs
@@ -45,6 +45,11 @@ namespace BauCore
         {
             get { return this.taskListType; }
         }
+        
+        public List<string> NamedParameters
+        {
+            get { throw new NotImplementedException(); }
+        }
 
         public bool Help
         {

--- a/src/Bau/Bau.cs
+++ b/src/Bau/Bau.cs
@@ -20,6 +20,7 @@ namespace BauCore
         private readonly bool help;
         private readonly Dictionary<string, IBauTask> tasks = new Dictionary<string, IBauTask>();
         private IBauTask currentTask;
+        private readonly BauScriptParameterContext parameterContext;
 
         public Bau(Arguments arguments)
         {
@@ -39,6 +40,11 @@ namespace BauCore
         public IBauTask CurrentTask
         {
             get { return this.currentTask; }
+        }
+
+        public BauScriptParameterContext GetParameterContext()
+        {
+            return parameterContext;
         }
 
         public ITaskBuilder DependsOn(params string[] otherTasks)

--- a/src/Bau/Bau.cs
+++ b/src/Bau/Bau.cs
@@ -35,6 +35,7 @@ namespace BauCore
             Log.LogLevel = arguments.LogLevel;
             this.taskListType = arguments.TaskListType;
             this.help = arguments.Help;
+            this.parameterContext = new BauScriptParameterContext(arguments.NamedParameters);
         }
 
         public IBauTask CurrentTask

--- a/src/Bau/Bau.csproj
+++ b/src/Bau/Bau.csproj
@@ -39,6 +39,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="BauScriptParameterContext.cs" />
     <Compile Include="ColorText.cs" />
     <Compile Include="ColorToken.cs" />
     <Compile Include="Log.cs" />

--- a/src/Bau/BauScriptParameterContext.cs
+++ b/src/Bau/BauScriptParameterContext.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+
+namespace BauCore
+{
+    public class BauScriptParameterContext
+    {
+        private readonly List<string> keyValuePairs;
+        private readonly bool throwIfNull;
+
+        public BauScriptParameterContext(List<string> keyValuePairs, bool throwIfNull = false)
+        {
+            this.keyValuePairs = keyValuePairs;
+            this.throwIfNull = throwIfNull;
+        }
+
+        public int Count
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public string this[string key]
+        {
+            get { throw new NotImplementedException(); }
+        }
+    }
+}

--- a/src/test/Bau.Test.Unit/ArgumentsFacts.cs
+++ b/src/test/Bau.Test.Unit/ArgumentsFacts.cs
@@ -87,5 +87,80 @@ namespace BauCore.Test.Unit
             // assert
             arguments.TaskListType.Should().Be(TaskListType.Json);
         }
+
+        [Theory]
+        [InlineData("-p", "FirstName=John")]
+        public static void CanParseParameter(string arg1, string arg2)
+        {
+            // arrange
+            var rawArgs = new[] { arg1, arg2 };
+
+            // act
+            var arguments = Arguments.Parse(rawArgs);
+
+            // assert
+            arguments.NamedParameters.Should().NotBeNull();            
+        }
+
+        [Theory]
+        [InlineData("-p", "FirstName=John")]
+        public static void CanParseSingleParameter(string arg1, string arg2)
+        {
+            // arrange
+            var rawArgs = new[] { arg1, arg2 };
+
+            // act
+            var arguments = Arguments.Parse(rawArgs);
+
+            // assert
+            arguments.NamedParameters.Count.Should().Be(1);    
+        }
+
+        [Theory]
+        [InlineData("-p", "FirstName=John", "-p", "LastName=Doe")]
+        public static void CanParseTwoParameters(string arg1, string arg2, string arg3, string arg4)
+        {
+            // arrange
+            var rawArgs = new[] { arg1, arg2, arg3, arg4 };
+
+            // act
+            var arguments = Arguments.Parse(rawArgs);
+
+            // assert
+            arguments.NamedParameters.Count.Should().Be(2);
+        }
+
+        [Theory]
+        [InlineData("-p", "FirstName=John", "-p", "LastName=Doe")]
+        public static void CanCreateParameterContextCount(string arg1, string arg2, string arg3, string arg4)
+        {
+            // arrange
+            var rawArgs = new[] { arg1, arg2, arg3, arg4 };
+
+            // act
+            var arguments = Arguments.Parse(rawArgs);
+
+            // assert
+            var parameterContext = new BauScriptParameterContext(arguments.NamedParameters);
+            parameterContext.Count.Should().Be(2);
+        }
+
+        [Theory]
+        [InlineData("-p", "FirstName=John", "-p", "LastName=Doe")]
+        public static void CanCreateParameterContext(string arg1, string arg2, string arg3, string arg4)
+        {
+            // arrange
+            var rawArgs = new[] { arg1, arg2, arg3, arg4 };
+
+            // act
+            var arguments = Arguments.Parse(rawArgs);
+
+            // assert
+            var parameterContext = new BauScriptParameterContext(arguments.NamedParameters);
+            var firstName = (string) parameterContext["FirstName"];
+            firstName.Should().Be("John");
+            var lastName = (string) parameterContext["LastName"];
+            lastName.Should().Be("Doe");
+        }
     }
 }


### PR DESCRIPTION
Hello!

This pull request provides a way to pass parameters to a bau script file - I based this off of the issue #212. I wanted this for what I am currently trying to achieve with bau!

Here is how you could possibly use it:

``` bash
C:\bau>scriptcs script_with_params.csx -- process_parameters -p FirstName=John -p LastName=Doe
```

Corresponding bau script file with details on how the context is retrieved and used.

``` csharp
var bau = Require<Bau>();
var parameters = bau.GetParameterContext();

bau
    .Task("process_parameters")
    .Do(() =>
    {
        Console.WriteLine("Parameters count: " + parameters.Count);
        Console.WriteLine("Parameter 'FirstName': " + parameters["FirstName"]);
        Console.WriteLine("Parameter 'LastName': " + parameters["LastName"]);
    })
.Run();
```

What follows is the output when running this script

``` text
C:\bau>scriptcs script_with_params.csx -- process_parameters -p FirstName=John -p LastName=Doe
[Bau] Bau 0.1.0 Copyright (c) Bau contributors (baubuildch@gmail.com)
[Bau] Running 'process_parameters' and dependencies...
[Bau] Starting 'process_parameters'...
Parameters count: 2
Parameter 'FirstName': John
Parameter 'LastName': Doe
[Bau] Finished 'process_parameters' after 8.58 ms.
[Bau] Completed 'process_parameters' and dependencies in 23.8 ms.
```

Please check it out!
